### PR TITLE
fix: Add Django and Flask to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
 pylint==2.3.1
+Django==2.2.5
 pylint-django==2.0.11
+Flask==1.1.1
 pylint-flask==0.6
 pylint-common==0.2.5
 pylint-celery==0.3


### PR DESCRIPTION
Django was not a transitive dependency of pylint-django. So the tool fails to import Django packages.