### PR TITLE
 Add `pylint-pytest==1.1.7` to requirements.txt

### DIFF
--- a/docs/patterns.json
+++ b/docs/patterns.json
@@ -1,6 +1,6 @@
 {
   "name": "pylintpython3",
-  "version": "3.0.2",
+  "version": "3.1.0",
   "patterns": [
     {
       "patternId": "E0103",

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ SaltPyLint==2023.8.3
 jsonpickle==3.0.2
 asttokens==2.4.1
 pylint-beam==0.1.2
+pylint-pytest==1.1.7


### PR DESCRIPTION
This PR adds `pylint-pytest` to the list of plugins for `codacy-pylint-python3`, enabling the opportunity to use this plugin during pull request checks.

Particularly, we need this plugin in [Tribler](https://github.com/Tribler/tribler). It would be really beneficial if we, as Codacy users, could specify our own plugin list. However, this isn't possible as the plugin list is limited to what's included in the https://github.com/codacy/codacy-pylint-python3/blob/master/requirements.txt.

Changes:
- Update "version" field in patterns.json from 3.0.2 to 3.1.0
- Add "pylint-pytest==1.1.7" to requirements.txt

I've tried to align with the style from the commit history, but I'm not sure that I've made all the necessary changes.
